### PR TITLE
Declare token to mitigate 'no token' exception when connection fails.

### DIFF
--- a/pyIsis/connection.py
+++ b/pyIsis/connection.py
@@ -45,6 +45,9 @@ class Client(object):
         self.hostname = hostname
         self.username = username
         self.password = password
+        
+        # must be present for __del__ to gracefully exit failed session
+        self.token = None
 
         url = ISIS_SOAP_URL.format(hostname=self.hostname,
                                    port=ISIS_SOAP_PORT)


### PR DESCRIPTION
When API fails to connect, the following warning is thrown from the destructor.

```
Exception AttributeError: "'Client' object has no attribute 'token'" in <bound method Client.__del__ of <pyIsis.connection.Client object at ... >> ignored
```

This PR addresses the issue by declaring a null token in the constructor.
