### PR TITLE
Added a port param in Client class to handle 2018.5+ nexis versions

### DIFF
--- a/pyIsis/connection.py
+++ b/pyIsis/connection.py
@@ -36,21 +36,23 @@ class Client(object):
         >>> client.get_workspaces()
     """
 
-    def __init__(self, hostname, username, password):
+    def __init__(self, hostname, username, password, port=80):
         """
             :param hostname: hostname or ip of the Avid Isis Storage server
             :param username: a valid username
             :param password: password of the user
+            :param port:     the port of the legacy web interface (80 or 3002)
         """
         self.hostname = hostname
         self.username = username
         self.password = password
+        self.port = port
         
         # must be present for __del__ to gracefully exit failed session
         self.token = None
 
         url = ISIS_SOAP_URL.format(hostname=self.hostname,
-                                   port=ISIS_SOAP_PORT)
+                                   port=self.port)
 
         try:
             self._client = osa.Client(url)
@@ -299,7 +301,7 @@ class Client(object):
 
 
     def _send(self, values):
-        url = 'http://%s/v2/ida' % self.hostname
+        url = 'http://%s:%s/v2/ida' % (self.hostname, self.port)
         authinfo = 'avidagent=12345; AdminServerToken=%s; AgentLoginName=%s' % \
                 (self.token, self.username)
         headers = {'User-Agent': '12345', 'Cookie': authinfo}

--- a/pyIsis/connection.py
+++ b/pyIsis/connection.py
@@ -36,7 +36,7 @@ class Client(object):
         >>> client.get_workspaces()
     """
 
-    def __init__(self, hostname, username, password, port=80):
+    def __init__(self, hostname, username, password, port=ISIS_SOAP_PORT):
         """
             :param hostname: hostname or ip of the Avid Isis Storage server
             :param username: a valid username


### PR DESCRIPTION
In Nexis version 2018.5 and above, the default web interface has changed on port 80, but the legacy web interface is still there on port 3002. 
Added a port parameter in the Client class to be able to change the port, left it at 80 by default for backwards compatibility.